### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/node-fast-plist/security/code-scanning/1](https://github.com/microsoft/node-fast-plist/security/code-scanning/1)

Generally, the fix is to add an explicit `permissions` block that restricts `GITHUB_TOKEN` as much as possible while still allowing the workflow to function. Since this workflow only checks out code, sets up Node, installs dependencies, compiles, and runs tests, it does not need to write to the repository or interact with issues/PRs. The minimal safe scope here is `contents: read`.

The best fix without changing functionality is to define a root-level `permissions` block (so it applies to all jobs) immediately after the `name: CI` line. This keeps the change small and clear, and avoids having to repeat the same permissions on every job. No additional imports or external libraries are needed; it’s purely a YAML configuration change.

Concretely: edit `.github/workflows/ci.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`). The rest of the file remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
